### PR TITLE
Fix the names of the libraries and invalid operands of types 'double' and 'long int' to binary 'operator%'

### DIFF
--- a/Interval.cpp
+++ b/Interval.cpp
@@ -26,8 +26,8 @@ extern "C" {
   #include <string.h>
   #include <inttypes.h>
 }
-#include <arduino.h>
-#include "interval.h"
+#include <Arduino.h>
+#include "Interval.h"
 
 // Public Methods //////////////////////////////////////////////////////////////
 uint32_t Interval::remains(void)

--- a/TimeClient.cpp
+++ b/TimeClient.cpp
@@ -135,7 +135,7 @@ long TimeClient::getCurrentEpoch() {
 }
 
 long TimeClient::getCurrentEpochWithUtcOffset() {
-  return round(getCurrentEpoch() + 3600 * myUtcOffset + 86400L) % 86400L;
+  return lround(getCurrentEpoch() + 3600 * myUtcOffset + 86400L) % 86400L;
 }
 
 int TimeClient::getHoursInt() {


### PR DESCRIPTION
I fixed the names of the libraries in the file Interval.cpp (missing the capital letters). And I fixed the TimeClient.cpp:138:67: error: invalid operands of types 'double' and 'long int' to binary 'operator%'
return round(getCurrentEpoch() + 3600 * myUtcOffset + 86400L) % 86400L;
I changed function round to lround.